### PR TITLE
Fix syntax error in register page - missing closing motion.div tag

### DIFF
--- a/app/app/auth/register/page.tsx
+++ b/app/app/auth/register/page.tsx
@@ -353,7 +353,7 @@ export default function RegisterPage() {
               Contact our support team
             </Link>
           </p>
-        </div>
+        </motion.div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
This PR fixes a syntax error in the register page that was causing the Netlify build to fail.

## Problem
The Netlify build was failing with the error:
```
Unexpected token `div`. Expected jsx identifier
```
at line 87 in `app/auth/register/page.tsx`.

## Solution
The issue was caused by a missing closing `</motion.div>` tag in the JSX structure. The footer section was using a regular `</div>` instead of `</motion.div>` to close the motion component.

## Changes
- Fixed the closing tag for the footer motion.div component
- Ensured proper JSX structure and syntax

## Testing
- [x] Code compiles without syntax errors
- [x] JSX structure is properly balanced
- [x] All motion.div components have matching closing tags

This fix should resolve the Netlify build failure and allow the deployment to proceed successfully.