### PR TITLE
Fix TypeScript compilation error: Replace Set spread operator with Array.from()

### DIFF
--- a/app/app/admin/venues/page.tsx
+++ b/app/app/admin/venues/page.tsx
@@ -124,7 +124,7 @@ export default function AdminVenuesPage() {
     });
   };
 
-  const cities = [...new Set(venues.map(venue => venue.city))].sort();
+  const cities = Array.from(new Set(venues.map(venue => venue.city))).sort();
 
   if (loading || !user || user.role !== 'SUPER_ADMIN') {
     return (


### PR DESCRIPTION
## Problem
TypeScript compilation was failing with the error:
```
Type 'Set<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.
```

This error occurred at line 127 in `app/admin/venues/page.tsx` where the spread operator was being used on a Set.

## Solution
Replaced the spread operator syntax with `Array.from()` to make it compatible with the current TypeScript target configuration:

**Before:**
```typescript
const cities = [...new Set(venues.map(venue => venue.city))].sort();
```

**After:**
```typescript
const cities = Array.from(new Set(venues.map(venue => venue.city))).sort();
```

## Impact
- ✅ Fixes TypeScript compilation error
- ✅ Maintains the same functionality (creates unique array of cities)
- ✅ Compatible with current TypeScript target configuration
- ✅ Allows Netlify deployment to proceed successfully

## Testing
The change is functionally equivalent - both approaches create an array of unique city names from the venues data and sort them alphabetically.